### PR TITLE
improve not_if validation of brew package

### DIFF
--- a/lib/itamae/plugin/recipe/homebrew/package.rb
+++ b/lib/itamae/plugin/recipe/homebrew/package.rb
@@ -2,8 +2,9 @@ include_recipe 'common.rb'
 
 # Install bin packages
 node['brew']['install_packages'].each do |package|
-  execute "Install package: #{package}" do
+  package_without_options = package.split(/[ \/]/).last
+  execute "Install package: #{package_without_options}" do
     command "brew install #{package}"
-    not_if "brew list | grep -q #{package}"
+    not_if "brew list | grep -q '#{package_without_options}$'"
   end
 end


### PR DESCRIPTION
If an element of install_packages has options or full path, not_if validation has broken.

My node has:

```
install_packages:
  - caskroom/cask/brew-cask
  - --HEAD neovim
  ...
```

When execute:

```
DEBUG :     execute[Install package: caskroom/cask/brew-cask]
DEBUG :       Executing `brew list | grep -q caskroom/cask/brew-cask`...
DEBUG :         exited with 1
DEBUG :       execute[Install package: caskroom/cask/brew-cask] action: run
DEBUG :         (in pre_action)
DEBUG :         (in set_current_attributes)
DEBUG :         (in show_differences)
INFO :         execute[Install package: caskroom/cask/brew-cask] executed will change from 'false' to 'true'
DEBUG :         Executing `brew install caskroom/cask/brew-cask`...
DEBUG :           exited with 0
DEBUG :         This resource is updated.
...
DEBUG :     execute[Install package: --HEAD neovim]
DEBUG :       Executing `brew list | grep -q --HEAD neovim`...
DEBUG :         stderr | grep: unrecognized option `--HEAD'
DEBUG :         stderr | usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
DEBUG :         stderr | [-e pattern] [-f file] [--binary-files=value] [--color=when]
DEBUG :         stderr | [--context[=num]] [--directories=action] [--label] [--line-buffered]
DEBUG :         stderr | [--null] [pattern] [file ...]
DEBUG :         exited with 2
```

I modified grep in not_if validation of brew package. Please confirm it.
