### PR TITLE
Use Itamae#logger instead of Logger

### DIFF
--- a/itamae-plugin-recipe-homebrew.gemspec
+++ b/itamae-plugin-recipe-homebrew.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "itamae", "~> 1.5"
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/lib/itamae/plugin/recipe/homebrew/common.rb
+++ b/lib/itamae/plugin/recipe/homebrew/common.rb
@@ -13,7 +13,7 @@ if enable_update
     command 'brew update'
   end
 else
-  Logger.info('Execution skipped Update brew because of not true enable_update')
+  Itamae.logger.info('Execution skipped Update brew because of not true enable_update')
 end
 
 # Upgrade brew
@@ -23,7 +23,7 @@ if enable_upgrade
     command 'brew upgrade'
   end
 else
-  Logger.info('Execution skipped Upgrade brew because of not true enable_upgrade')
+  Itamae.logger.info('Execution skipped Upgrade brew because of not true enable_upgrade')
 end
 
 # Add Repository


### PR DESCRIPTION
Itamae v1.5 has a logger injectable from outside of itamae. So, can not use `Logger` on itamae v1.5.
https://github.com/itamae-kitchen/itamae/blob/master/CHANGELOG.md#v150
