### PR TITLE
Make `add_repositories` parameter to optionally

### DIFF
--- a/lib/itamae/plugin/recipe/homebrew/common.rb
+++ b/lib/itamae/plugin/recipe/homebrew/common.rb
@@ -27,7 +27,7 @@ else
 end
 
 # Add Repository
-node['brew']['add_repositories'].each do |repo|
+node['brew']['add_repositories'].try(:each) do |repo|
   execute "Add Repository: #{repo}" do
     command "brew tap #{repo}"
     not_if "brew tap | grep -q #{repo}"


### PR DESCRIPTION
Hi.
Currently, `add_repositories` parameter is required. So error raise if this parameter doesn't exist.
 I don't want to raise an error.